### PR TITLE
Move clientID check out of Accept()

### DIFF
--- a/client.go
+++ b/client.go
@@ -3,6 +3,7 @@ package gorpc
 import (
 	"fmt"
 	"io"
+	"net"
 	"sync"
 	"time"
 )
@@ -501,7 +502,7 @@ func (e *ClientError) Error() string {
 func clientHandler(c *Client) {
 	defer c.stopWg.Done()
 
-	var conn io.ReadWriteCloser
+	var conn net.Conn
 	var err error
 
 	for {
@@ -529,9 +530,9 @@ func clientHandler(c *Client) {
 	}
 }
 
-func clientHandleConnection(c *Client, conn io.ReadWriteCloser) {
+func clientHandleConnection(c *Client, conn net.Conn) {
 	if c.OnConnect != nil {
-		newConn, err := c.OnConnect(c.Addr, conn)
+		newConn, _, err := c.OnConnect(conn)
 		if err != nil {
 			c.LogError("gorpc.Client: [%s]. OnConnect error: [%s]", c.Addr, err)
 			conn.Close()

--- a/common.go
+++ b/common.go
@@ -2,8 +2,8 @@ package gorpc
 
 import (
 	"fmt"
-	"io"
 	"log"
+	"net"
 	"sync"
 	"time"
 )
@@ -41,7 +41,7 @@ const (
 //
 // The callback may be used for authentication/authorization and/or custom
 // transport wrapping.
-type OnConnectFunc func(remoteAddr string, rwc io.ReadWriteCloser) (io.ReadWriteCloser, error)
+type OnConnectFunc func(rwc net.Conn) (net.Conn, string, error)
 
 // LoggerFunc is an error logging function to pass to gorpc.SetErrorLogger().
 type LoggerFunc func(format string, args ...interface{})


### PR DESCRIPTION
Gorpc server use clientID (which by default client IP), to dispatch client messages.
In the case of Tyk it was causing issues since when hybrid traffic goes through the proxy, behind MDCB, original IP gets lost, and all clients look the same. It was causing issues when clients did not received messages in some cases. We solved it by introducing additional protocol handshake, on which Gateway sends its UUID, which will be used as clientID instead of IP.

We had to implement handshake functionality inside Accept() function, because of Gorpc design. Accept() in networking applications should be non blocking, but in our case we did a few connections reads inside it, which in most cases was fine (since they are fast), but in some cases it was blocking for a long period of time, because of network timeout and etc (for example in case of TCP health-checks).

This change moves `clientID` logic out of `Accept()` function to `OnConnect()` hook, and MDCB does its handshake logic inside it. If `OnConnect` is not set, it falls back to connection IP.

Additionally, all connection variables set to `net.Conn` type. 