### PR TITLE
Updte with origin

### DIFF
--- a/client.go
+++ b/client.go
@@ -3,6 +3,7 @@ package gorpc
 import (
 	"fmt"
 	"io"
+	"net"
 	"sync"
 	"time"
 )
@@ -501,7 +502,7 @@ func (e *ClientError) Error() string {
 func clientHandler(c *Client) {
 	defer c.stopWg.Done()
 
-	var conn io.ReadWriteCloser
+	var conn net.Conn
 	var err error
 
 	for {
@@ -529,9 +530,9 @@ func clientHandler(c *Client) {
 	}
 }
 
-func clientHandleConnection(c *Client, conn io.ReadWriteCloser) {
+func clientHandleConnection(c *Client, conn net.Conn) {
 	if c.OnConnect != nil {
-		newConn, err := c.OnConnect(c.Addr, conn)
+		newConn, _, err := c.OnConnect(conn)
 		if err != nil {
 			c.LogError("gorpc.Client: [%s]. OnConnect error: [%s]", c.Addr, err)
 			conn.Close()

--- a/common.go
+++ b/common.go
@@ -2,8 +2,8 @@ package gorpc
 
 import (
 	"fmt"
-	"io"
 	"log"
+	"net"
 	"sync"
 	"time"
 )
@@ -41,7 +41,7 @@ const (
 //
 // The callback may be used for authentication/authorization and/or custom
 // transport wrapping.
-type OnConnectFunc func(remoteAddr string, rwc io.ReadWriteCloser) (io.ReadWriteCloser, error)
+type OnConnectFunc func(rwc net.Conn) (net.Conn, string, error)
 
 // LoggerFunc is an error logging function to pass to gorpc.SetErrorLogger().
 type LoggerFunc func(format string, args ...interface{})

--- a/conn_stats.go
+++ b/conn_stats.go
@@ -52,6 +52,8 @@ type ConnStats struct {
 	// The number of Accept() errors.
 	AcceptErrors uint64
 
+	FuncCallStats map[string]uint64
+
 	// lock is for 386 builds. See https://github.com/valyala/gorpc/issues/5 .
 	lock sync.Mutex
 }

--- a/conn_stats_386.go
+++ b/conn_stats_386.go
@@ -37,10 +37,11 @@ func (cs *ConnStats) Reset() {
 	cs.DialErrors = 0
 	cs.AcceptCalls = 0
 	cs.AcceptErrors = 0
+	cs.FuncCallStats = make(map[string]uint64)
 	cs.lock.Unlock()
 }
 
-func (cs *ConnStats) incRPCCalls() {
+func (cs *ConnStats) incRPCCalls(fn string) {
 	cs.lock.Lock()
 	cs.RPCCalls++
 	cs.lock.Unlock()
@@ -110,4 +111,11 @@ func (cs *ConnStats) incAcceptErrors() {
 	cs.lock.Lock()
 	cs.AcceptErrors++
 	cs.lock.Unlock()
+}
+
+func (cs *ConnStats) incFuncCalls(fn string) {
+	if cs.FuncCallStats == nil {
+		cs.FuncCallStats = make(map[string]uint64)
+	}
+	cs.FuncCallStats[fn]++
 }

--- a/conn_stats_386.go
+++ b/conn_stats_386.go
@@ -114,8 +114,10 @@ func (cs *ConnStats) incAcceptErrors() {
 }
 
 func (cs *ConnStats) incFuncCalls(fn string) {
+	cs.lock.Lock()
 	if cs.FuncCallStats == nil {
 		cs.FuncCallStats = make(map[string]uint64)
 	}
 	cs.FuncCallStats[fn]++
+	cs.lock.Unlock()
 }

--- a/conn_stats_386.go
+++ b/conn_stats_386.go
@@ -41,7 +41,7 @@ func (cs *ConnStats) Reset() {
 	cs.lock.Unlock()
 }
 
-func (cs *ConnStats) incRPCCalls(fn string) {
+func (cs *ConnStats) incRPCCalls() {
 	cs.lock.Lock()
 	cs.RPCCalls++
 	cs.lock.Unlock()

--- a/conn_stats_generic.go
+++ b/conn_stats_generic.go
@@ -12,18 +12,19 @@ import (
 // since the original stats can be updated by concurrently running goroutines.
 func (cs *ConnStats) Snapshot() *ConnStats {
 	return &ConnStats{
-		RPCCalls:     atomic.LoadUint64(&cs.RPCCalls),
-		RPCTime:      atomic.LoadUint64(&cs.RPCTime),
-		BytesWritten: atomic.LoadUint64(&cs.BytesWritten),
-		BytesRead:    atomic.LoadUint64(&cs.BytesRead),
-		ReadCalls:    atomic.LoadUint64(&cs.ReadCalls),
-		ReadErrors:   atomic.LoadUint64(&cs.ReadErrors),
-		WriteCalls:   atomic.LoadUint64(&cs.WriteCalls),
-		WriteErrors:  atomic.LoadUint64(&cs.WriteErrors),
-		DialCalls:    atomic.LoadUint64(&cs.DialCalls),
-		DialErrors:   atomic.LoadUint64(&cs.DialErrors),
-		AcceptCalls:  atomic.LoadUint64(&cs.AcceptCalls),
-		AcceptErrors: atomic.LoadUint64(&cs.AcceptErrors),
+		RPCCalls:      atomic.LoadUint64(&cs.RPCCalls),
+		RPCTime:       atomic.LoadUint64(&cs.RPCTime),
+		BytesWritten:  atomic.LoadUint64(&cs.BytesWritten),
+		BytesRead:     atomic.LoadUint64(&cs.BytesRead),
+		ReadCalls:     atomic.LoadUint64(&cs.ReadCalls),
+		ReadErrors:    atomic.LoadUint64(&cs.ReadErrors),
+		WriteCalls:    atomic.LoadUint64(&cs.WriteCalls),
+		WriteErrors:   atomic.LoadUint64(&cs.WriteErrors),
+		DialCalls:     atomic.LoadUint64(&cs.DialCalls),
+		DialErrors:    atomic.LoadUint64(&cs.DialErrors),
+		AcceptCalls:   atomic.LoadUint64(&cs.AcceptCalls),
+		AcceptErrors:  atomic.LoadUint64(&cs.AcceptErrors),
+		FuncCallStats: cs.FuncCallStats,
 	}
 }
 
@@ -41,6 +42,7 @@ func (cs *ConnStats) Reset() {
 	atomic.StoreUint64(&cs.DialErrors, 0)
 	atomic.StoreUint64(&cs.AcceptCalls, 0)
 	atomic.StoreUint64(&cs.AcceptErrors, 0)
+	cs.FuncCallStats = make(map[string]uint64)
 }
 
 func (cs *ConnStats) incRPCCalls() {
@@ -89,4 +91,11 @@ func (cs *ConnStats) incAcceptCalls() {
 
 func (cs *ConnStats) incAcceptErrors() {
 	atomic.AddUint64(&cs.AcceptErrors, 1)
+}
+
+func (cs *ConnStats) incFuncCalls(fn string) {
+	if cs.FuncCallStats == nil {
+		cs.FuncCallStats = make(map[string]uint64)
+	}
+	cs.FuncCallStats[fn]++
 }

--- a/conn_stats_generic.go
+++ b/conn_stats_generic.go
@@ -94,8 +94,10 @@ func (cs *ConnStats) incAcceptErrors() {
 }
 
 func (cs *ConnStats) incFuncCalls(fn string) {
+	cs.lock.Lock()
 	if cs.FuncCallStats == nil {
 		cs.FuncCallStats = make(map[string]uint64)
 	}
 	cs.FuncCallStats[fn]++
+	cs.lock.Unlock()
 }

--- a/dispatcher.go
+++ b/dispatcher.go
@@ -238,7 +238,7 @@ func validateType(t reflect.Type) (err error) {
 	})
 
 	switch t.Kind() {
-	case reflect.Chan, reflect.Func, reflect.Interface, reflect.UnsafePointer:
+	case reflect.Chan, reflect.Func, reflect.UnsafePointer:
 		err = fmt.Errorf("%s. Found [%s]", t.Kind(), t)
 		return
 	case reflect.Array, reflect.Slice:
@@ -365,7 +365,7 @@ func dispatchRequest(serviceMap map[string]*serviceData, clientAddr string, req 
 		if fd.inNum > dt {
 			reqv := reflect.ValueOf(req.Request)
 			reqt := reflect.TypeOf(req.Request)
-			if reqt != fd.reqt {
+			if fd.reqt.String() != "interface {}" && reqt != fd.reqt {
 				return &dispatcherResponse{
 					Error: fmt.Sprintf("gorpc.Dispatcher: unexpected request type for method [%s]: %s. Expected %s", req.Name, reqt, fd.reqt),
 				}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/TykTechnologies/gorpc
+
+go 1.15

--- a/server.go
+++ b/server.go
@@ -215,9 +215,11 @@ func serverHandler(s *Server, workersCh chan struct{}) {
 func serverHandleConnection(s *Server, conn net.Conn, workersCh chan struct{}) {
 	defer s.stopWg.Done()
 	var clientAddr string
+	var err error
+	var newConn net.Conn
 
 	if s.OnConnect != nil {
-		newConn, clientAddr, err := s.OnConnect(conn)
+		newConn, clientAddr, err = s.OnConnect(conn)
 		if err != nil {
 			s.LogError("gorpc.Server: [%s]->[%s]. OnConnect error: [%s]", clientAddr, s.Addr, err)
 			conn.Close()
@@ -231,7 +233,6 @@ func serverHandleConnection(s *Server, conn net.Conn, workersCh chan struct{}) {
 	}
 
 	var enabledCompression bool
-	var err error
 	zChan := make(chan bool, 1)
 	go func() {
 		var buf [1]byte

--- a/server.go
+++ b/server.go
@@ -354,6 +354,13 @@ func serveRequest(s *Server, responsesChan chan<- *serverMessage, stopChan <-cha
 	response, err := callHandlerWithRecover(s.LogError, s.Handler, clientAddr, s.Addr, request)
 	s.Stats.incRPCTime(uint64(time.Since(t).Seconds() * 1000))
 
+	req, ok := request.(*dispatcherRequest)
+	if !ok {
+		logPanic("gorpc.Dispatcher: unsupported request type received from the client: %T", request)
+	} else {
+		s.Stats.incFuncCalls(req.Name)
+	}
+
 	if !skipResponse {
 		m.Response = response
 		m.Error = err


### PR DESCRIPTION
Updated some of the code of server.go with the latest available in [https://github.com/valyala/gorpc](https://github.com/valyala/gorpc)

Some of the changes are:
- Suppress more 'EOF' log messages when clien disconnects from the server or Server.Stop() has been called
- Do not log 'closed conn'-like error messages on server side after Server.Stop()
- Increase the probability of message batching on both client and server by calling `runtime.Gosched() `after requests/responses channels have been drained. This should reduce the number of write() syscalls (especially on go1.5)